### PR TITLE
Use DOMContentLoaded event instead of load event

### DIFF
--- a/src/resources/script.js
+++ b/src/resources/script.js
@@ -1,4 +1,4 @@
-window.onload = function () {
+document.addEventListener('DOMContentLoaded', function () {
     /*
      * addEventListner: For all major browsers, except IE 8 and earlier
      * attachEvent:     For IE 8 and earlier versions
@@ -30,7 +30,7 @@ window.onload = function () {
     } else if (tabLink.attachEvent) {
         tabLink.attachEvent("onclick", toggleTab);
     }
-};
+});
 
 function submitConsent(event) {
 


### PR DESCRIPTION
Using the `window.load` event waits until the page is finished loading before running.
This causes an issue where if someone accepts cookies while an asset is still loading, they will be taken to a different page that just says `true`.

Using the `DOMContentLoaded` should accomplish what the `load` event was doing, but in a way that makes it not depend on having fully loaded assets.

I believe this also resolves issue #11 