### PR TITLE
Fix missing table field actions

### DIFF
--- a/src/templates/settings/_includes/group.twig
+++ b/src/templates/settings/_includes/group.twig
@@ -78,6 +78,9 @@
     name: 'cookies',
     label: group.getAttributeLabel('cookies'),
     required: false,
+    allowAdd: true,
+    allowReorder: true,
+    allowDelete: true,
     cols: {
         name: {
             heading: "Cookie-name"|t('cookie-consent'),


### PR DESCRIPTION
Brings back the missing table field actions to add, reorder and delete rows.

See the issue https://github.com/elleracompany/craft-cookie-consent/issues/90 and https://github.com/elleracompany/craft-cookie-consent/issues/91 for details.