### PR TITLE
PR with two small "quality of live" changes

### DIFF
--- a/src/templates/banner.twig
+++ b/src/templates/banner.twig
@@ -12,7 +12,7 @@
 
         <header class="elc-header">
             <h3 class="elc-primary-heading">{{ craft.cookieConsent.headline }}</h3>
-            <p class="elc-header-description">{{ craft.cookieConsent.description }}</p>
+            <p class="elc-header-description">{{ craft.cookieConsent.description|raw }}</p>
         </header>
 
         <div id="elc-cookie-consent-settings"{% if craft.cookieConsent.hideCheckboxes %} class="elc-hide-when-small"{% endif %}>
@@ -23,7 +23,7 @@
                         <label class="elc-cookie-name" for="elc-checkbox-{{loop.index}}">{{ group.name }}{% if group.required == 1 %} <small>({{ "Required"|t }})</small>{% endif %}</label>
                     </div>
                     <div class="elc-row elc-cookie-description">
-                        {{ group.description }}
+                        {{ group.description|raw }}
                     </div>
                     {% for cookie in group.cookies|json_decode %}
                         <div class="elc-cookie">

--- a/src/templates/settings/index.twig
+++ b/src/templates/settings/index.twig
@@ -1,6 +1,6 @@
 {% extends "cookie-consent/settings/_layout.twig" %}
 {% block content %}
-    {{ content|markdown }}
+    {{ content|markdown('gfm) }}
 {% endblock %}
 {% block actionButton %}
 


### PR DESCRIPTION
1. Filter markdown to make the README file more readable
See Craft CMS documentation for details: https://craftcms.com/docs/3.x/dev/filters.html#markdown-or-md.

2. Allow HTML in description fields
This little change allows using HTML in the description fields. We often have links to privacy policy pages. This change makes this possible to render correctly, without changing the banner template file.